### PR TITLE
Remove single quote to fix GitHub's syntax highlighting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ class App extends Component {
     return (
       <MyProvider>
         <div>
-          <p>I'm the app</p>
+          <p>I am the app</p>
           <Family />
         </div>
       </MyProvider>


### PR DESCRIPTION
Fixes #2 